### PR TITLE
fix(path-util): fix path-util type define

### DIFF
--- a/packages/path-util/package.json
+++ b/packages/path-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/path-util",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "description": "A common util collection for antv projects",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,8 @@
     "lib": [
       "dom",
       "es7"
-    ]
+    ],
+    "types": ["mocha"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
已经发布到 npm 的 path-util 的版本是 2.0.3，但是代码最新的还是 2.0.2，并且这个 2.0.2 的代码中 `path-2-curve.ts` 类型定义不正确。

解法：修改代码版本，重新发布。