### PR TITLE
refactor: use gl-matrix as dependence

### DIFF
--- a/packages/matrix-util/package.json
+++ b/packages/matrix-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/matrix-util",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A common util collection for antv projects",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -45,8 +45,8 @@
   },
   "homepage": "https://github.com/antvis/util#readme",
   "dependencies": {
-    "@antv/gl-matrix": "^2.7.1",
     "@antv/util": "^2.0.7",
+    "gl-matrix": "^3.3.0",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/matrix-util/src/mat3.ts
+++ b/packages/matrix-util/src/mat3.ts
@@ -1,4 +1,4 @@
-import * as mat3 from '@antv/gl-matrix/lib/gl-matrix/mat3';
+import * as mat3 from 'gl-matrix/mat3';
 
 mat3.translate = function (out, a, v) {
   const transMat = new Array(9);

--- a/packages/matrix-util/src/vec2.ts
+++ b/packages/matrix-util/src/vec2.ts
@@ -1,5 +1,5 @@
-import * as vec2 from '@antv/gl-matrix/lib/gl-matrix/vec2';
 import { clamp } from '@antv/util';
+import * as vec2 from 'gl-matrix/vec2';
 
 vec2.angle = function (v1, v2) {
   const theta = vec2.dot(v1, v2) / (vec2.length(v1) * vec2.length(v2));

--- a/packages/matrix-util/src/vec3.ts
+++ b/packages/matrix-util/src/vec3.ts
@@ -1,3 +1,3 @@
-import * as vec3 from '@antv/gl-matrix/lib/gl-matrix/vec3';
+import * as vec3 from 'gl-matrix/vec3';
 
 export default vec3;


### PR DESCRIPTION
 - [x] gl-matrix 已经支持按需加载，且提供自己的类型定义，所以无需使用 fork 的 @antvis/gl-matrix 了
 
后续 g 改成直接依赖 matrix-util，否则上层 g2、g2plot 可能具有两份 matrix 的包大小，大概 50kb。

ref https://github.com/antvis/G2/issues/2317 、https://github.com/antvis/g/pull/483