### PR TITLE
feat(dom-util): 新增返回事件路径以兼容所有浏览器

### DIFF
--- a/packages/dom-util/__tests__/unit/dom-spec.js
+++ b/packages/dom-util/__tests__/unit/dom-spec.js
@@ -58,4 +58,10 @@ describe('DomUtils', () => {
       DOMUtil.addEventListener(nodeNotExist, 'click', () => {});
     }).to.not.throw();
   });
+
+  it('getEventPath(event)', () => {
+    expect(() => {
+      DOMUtil.getEventPath(nodeNotExist);
+    }).to.not.throw();
+  });
 });

--- a/packages/dom-util/src/get-event-path.ts
+++ b/packages/dom-util/src/get-event-path.ts
@@ -1,0 +1,28 @@
+/**
+ * 返回事件路径
+ * @param event 事件
+ */
+
+export default function getEventPath(event: MouseEvent): Array<EventTarget> {
+  if(!event) {
+    return;
+  }
+
+  if (event.composedPath) {
+    return event.composedPath();
+  }
+
+  const path = [];
+  let el = event.target as HTMLElement;
+
+  while (el) {
+    path.push(el);
+    if (el.tagName === 'HTML') {
+      path.push(document, window);
+      return path;
+    }
+
+    el = el.parentElement;
+  }
+  return path;
+}

--- a/packages/dom-util/src/index.ts
+++ b/packages/dom-util/src/index.ts
@@ -1,6 +1,7 @@
 // dom
 export { default as addEventListener } from './add-event-listener';
 export { default as createDom } from './create-dom';
+export { default as getEventPath } from './get-event-path';
 export { default as getHeight } from './get-height';
 export { default as getOuterHeight } from './get-outer-height';
 export { default as getOuterWidth } from './get-outer-width';


### PR DESCRIPTION
在G6中的[toolBar](https://github.com/antvis/G6/blob/master/src/plugins/toolBar/index.ts#L117)发现一个兼容性问题，IE、火狐等浏览器 （[issue](https://github.com/antvis/G6/issues/2315)也有提及）不支持event.path，我认为可以抽离出来放到util中，方便G6引用以兼容所有浏览器。

代码参考[stackoverflow](https://stackoverflow.com/questions/39245488/event-path-is-undefined-running-in-firefox)