### PR TITLE
feat: expose arcToCubic API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/util",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "MIT",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -4,6 +4,7 @@ export { path2Absolute } from './convert/path-2-absolute';
 export { clonePath } from './process/clone-path';
 export { normalizePath } from './process/normalize-path';
 export { reverseCurve } from './process/reverse-curve';
+export { arcToCubic } from './process/arc-2-cubic';
 export { getPathBBox } from './util/get-path-bbox';
 export { getTotalLength } from './util/get-total-length';
 export { getPathBBoxTotalLength } from './util/get-path-bbox-total-length';


### PR DESCRIPTION
需要推迟转换成贝塞尔曲线的时机，因此需要暴露转换方法：
https://github.com/antvis/G/issues/1193
