### PR TITLE
fix: move gl-matrix from peerdeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "util",
     "antv"
   ],
-  "peerDependencies": {
-    "gl-matrix": "^3.3.0"
-  },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@rollup/plugin-commonjs": "^22.0.0",
@@ -44,7 +41,6 @@
     "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^7.22.0",
     "eslint-plugin-import": "^2.22.1",
-    "gl-matrix": "^3.3.0",
     "husky": "^5.0.9",
     "jest": "^26.6.3",
     "jest-electron": "^0.1.12",
@@ -94,6 +90,7 @@
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
+    "gl-matrix": "^3.3.0",
     "tslib": "^2.3.1"
   }
 }


### PR DESCRIPTION
https://github.com/antvis/G/issues/1249

将 `gl-matrix` 从 peerdeps 中移动到 deps 中