### PR TITLE
chore: benchmarks for path2String & path2Absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,27 @@ isPointInPolygon(polygon, 0, 0); // true
 isPolygonsIntersect(polygon1, polygon2);
 ```
 
+## Benchmarks
+
+Build first.
+
+```bash
+yarn run benchmarks
+```
+
+We can get the following output in the console, it can be seen that the same method from 5.0 is ~3 times faster than 4.0.
+
+```js
+// logs
+// Path2String#4.0 x 14,795 ops/sec ±3.35% (79 runs sampled)
+// Path2String#5.0 x 51,710 ops/sec ±2.05% (85 runs sampled)
+// Fastest is Path2String#5.0
+
+// Path2Absolute#4.0 x 14,524 ops/sec ±2.55% (80 runs sampled)
+// Path2Absolute#5.0 x 35,120 ops/sec ±3.10% (81 runs sampled)
+// Fastest is Path2Absolute#5.0
+```
+
 ## License
 
 MIT@[AntV](https://github.com/antvis).

--- a/benchmarks/path-2-absolute.test.js
+++ b/benchmarks/path-2-absolute.test.js
@@ -1,0 +1,32 @@
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+var { path2Absolute: path2Absolute40 } = require('@antv/path-util'); // 4.0
+var { path2Absolute: path2Absolute50 } = require('../lib'); // 5.0
+
+// add tests
+suite
+  .add('Path2Absolute#4.0', function () {
+    path2Absolute40(
+      'M2 4a2 2 0 0 0 -2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-6a2 2 0 0 0 -2 -2h-1.172a2 2 0 0 1 -1.414 -0.586l-0.828 -0.828a2 2 0 0 0 -1.414 -0.586h-2.344a2 2 0 0 0 -1.414 0.586l-0.828 0.828a2 2 0 0 1 -1.414 0.586h-1.172zM10.5 8.5a2.5 2.5 0 0 0 -5 0a2.5 2.5 0 1 0 5 0zM2.5 6a0.5 0.5 0 0 1 0 -1a0.5 0.5 0 1 1 0 1zM11.5 8.5a3.5 3.5 0 1 1 -7 0a3.5 3.5 0 0 1 7 0z',
+    );
+  })
+  .add('Path2Absolute#5.0', function () {
+    path2Absolute50(
+      'M2 4a2 2 0 0 0 -2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-6a2 2 0 0 0 -2 -2h-1.172a2 2 0 0 1 -1.414 -0.586l-0.828 -0.828a2 2 0 0 0 -1.414 -0.586h-2.344a2 2 0 0 0 -1.414 0.586l-0.828 0.828a2 2 0 0 1 -1.414 0.586h-1.172zM10.5 8.5a2.5 2.5 0 0 0 -5 0a2.5 2.5 0 1 0 5 0zM2.5 6a0.5 0.5 0 0 1 0 -1a0.5 0.5 0 1 1 0 1zM11.5 8.5a3.5 3.5 0 1 1 -7 0a3.5 3.5 0 0 1 7 0z',
+    );
+  })
+  // add listeners
+  .on('cycle', function (event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
+  })
+  // run async
+  .run({ async: true });
+
+// logs:
+// Path2Absolute#4.0 x 14,524 ops/sec ±2.55% (80 runs sampled)
+// Path2Absolute#5.0 x 35,120 ops/sec ±3.10% (81 runs sampled)
+// Fastest is Path2Absolute#5.0

--- a/benchmarks/path-2-string.test.js
+++ b/benchmarks/path-2-string.test.js
@@ -1,0 +1,32 @@
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+var { parsePathString: parsePathString40 } = require('@antv/path-util'); // 4.0
+var { parsePathString: parsePathString50 } = require('../lib/path/parser/parse-path-string'); // 5.0
+
+// add tests
+suite
+  .add('Path2String#4.0', function () {
+    parsePathString40(
+      'M2 4a2 2 0 0 0 -2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-6a2 2 0 0 0 -2 -2h-1.172a2 2 0 0 1 -1.414 -0.586l-0.828 -0.828a2 2 0 0 0 -1.414 -0.586h-2.344a2 2 0 0 0 -1.414 0.586l-0.828 0.828a2 2 0 0 1 -1.414 0.586h-1.172zM10.5 8.5a2.5 2.5 0 0 0 -5 0a2.5 2.5 0 1 0 5 0zM2.5 6a0.5 0.5 0 0 1 0 -1a0.5 0.5 0 1 1 0 1zM11.5 8.5a3.5 3.5 0 1 1 -7 0a3.5 3.5 0 0 1 7 0z',
+    );
+  })
+  .add('Path2String#5.0', function () {
+    parsePathString50(
+      'M2 4a2 2 0 0 0 -2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-6a2 2 0 0 0 -2 -2h-1.172a2 2 0 0 1 -1.414 -0.586l-0.828 -0.828a2 2 0 0 0 -1.414 -0.586h-2.344a2 2 0 0 0 -1.414 0.586l-0.828 0.828a2 2 0 0 1 -1.414 0.586h-1.172zM10.5 8.5a2.5 2.5 0 0 0 -5 0a2.5 2.5 0 1 0 5 0zM2.5 6a0.5 0.5 0 0 1 0 -1a0.5 0.5 0 1 1 0 1zM11.5 8.5a3.5 3.5 0 1 1 -7 0a3.5 3.5 0 0 1 7 0z',
+    );
+  })
+  // add listeners
+  .on('cycle', function (event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
+  })
+  // run async
+  .run({ async: true });
+
+// logs:
+// Path2String#4.0 x 14,795 ops/sec ±3.35% (79 runs sampled)
+// Path2String#5.0 x 51,710 ops/sec ±2.05% (85 runs sampled)
+// Fastest is Path2String#5.0

--- a/package.json
+++ b/package.json
@@ -25,13 +25,15 @@
     "build:esm": "rimraf ./esm && tsc --module ESNext --outDir esm",
     "build": "run-p build:*",
     "ci": "run-s lint test build",
-    "prepublishOnly": "npm run ci"
+    "prepublishOnly": "npm run ci",
+    "benchmarks": "node benchmarks/path-2-string.test && node benchmarks/path-2-absolute.test"
   },
   "keywords": [
     "util",
     "antv"
   ],
   "devDependencies": {
+    "@antv/path-util": "^2.0.15",
     "@commitlint/cli": "^11.0.0",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
@@ -39,6 +41,7 @@
     "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
+    "benchmark": "^2.1.4",
     "eslint": "^7.22.0",
     "eslint-plugin-import": "^2.22.1",
     "husky": "^5.0.9",


### PR DESCRIPTION
在 Path 初始化时会调用这两个方法，用于将字符串例如 `'M 100 100 l 200 200'` 转换成包含绝对命令的 PathArray：

```bash
$ yarn benchmarks
```

相比 2.x `@antv/path-util` 也就是 G 4.0 中使用的方法，3.x 的要快 3 倍左右：

```log
Path2String#4.0 x 14,253 ops/sec ±3.62% (80 runs sampled)
Path2String#5.0 x 50,066 ops/sec ±2.89% (84 runs sampled)
Fastest is Path2String#5.0

Path2Absolute#4.0 x 14,524 ops/sec ±2.55% (80 runs sampled)
Path2Absolute#5.0 x 35,120 ops/sec ±3.10% (81 runs sampled)
Fastest is Path2Absolute#5.0
```

测试使用了 [benchmarks.js](https://github.com/bestiejs/benchmark.js)，使用新旧版本对同样的 Path 字符串进行转换。