### PR TITLE
fix: use `Document` replace `HTMLDocument`

### DIFF
--- a/src/lodash/is-element.ts
+++ b/src/lodash/is-element.ts
@@ -3,6 +3,6 @@
  * @return {Boolean} 是否HTML元素
  */
 const isElement = function (o: any): boolean {
-  return o instanceof Element || o instanceof HTMLDocument;
+  return o instanceof Element || o instanceof Document;
 };
 export default isElement;


### PR DESCRIPTION
`HTMLDocument` is deprecated and it blocked the test, something like '`HTMLDocument` not found'