### PR TITLE
fix: sourcemap not found

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "pretty": true,
     "lib": ["dom", "esnext"],
     "skipLibCheck": true,
-    "sourceRoot": "src",
     "baseUrl": "src"
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Fix #112 

Example: esm/index.js.map

Before
```
{"version":3,"file":"index.js","sourceRoot":"src/","sources":["index.ts"],"names":[],"mappings":"AAAA,cAAc,SAAS,CAAC;AACxB,cAAc,UAAU,CAAC;AACzB,cAAc,QAAQ,CAAC;AACvB,cAAc,UAAU,CAAC;AACzB,cAAc,QAAQ,CAAC;AACvB,cAAc,OAAO,CAAC"}
```

After
```
{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,cAAc,SAAS,CAAC;AACxB,cAAc,UAAU,CAAC;AACzB,cAAc,QAAQ,CAAC;AACvB,cAAc,UAAU,CAAC;AACzB,cAAc,QAAQ,CAAC;AACvB,cAAc,OAAO,CAAC"}
```
